### PR TITLE
test : [019-SIGNUP-TEST] 회원 가입 테스트 코드 구현

### DIFF
--- a/user-api/src/main/java/com/zerobase/cms/user/UserApplication.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/UserApplication.java
@@ -4,13 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.ServletComponentScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @ServletComponentScan
 @EnableFeignClients
 @SpringBootApplication
-@EnableJpaAuditing
 @EnableJpaRepositories
 public class UserApplication {
 

--- a/user-api/src/main/java/com/zerobase/cms/user/config/JpaAuditingConfiguration.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/config/JpaAuditingConfiguration.java
@@ -1,0 +1,10 @@
+package com.zerobase.cms.user.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/service/customer/SignUpCustomerService.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/service/customer/SignUpCustomerService.java
@@ -39,6 +39,7 @@ public class SignUpCustomerService {
             throw new CustomException(ErrorCode.EXPIRE_CODE);
         }
         customer.setVerify(true);
+        customerRepository.save(customer);
     }
 
     @Transactional

--- a/user-api/src/main/java/com/zerobase/cms/user/service/seller/SellerService.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/service/seller/SellerService.java
@@ -51,6 +51,7 @@ public class SellerService {
             throw new CustomException(ErrorCode.EXPIRE_CODE);
         }
         seller.setVerify(true);
+        sellerRepository.save(seller);
     }
 
     @Transactional

--- a/user-api/src/test/java/com/zerobase/cms/user/application/SignUpApplicationTest.java
+++ b/user-api/src/test/java/com/zerobase/cms/user/application/SignUpApplicationTest.java
@@ -1,0 +1,210 @@
+package com.zerobase.cms.user.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+import com.zerobase.cms.user.client.MailgunClient;
+import com.zerobase.cms.user.domain.SignUpForm;
+import com.zerobase.cms.user.domain.model.Customer;
+import com.zerobase.cms.user.domain.model.Seller;
+import com.zerobase.cms.user.exception.CustomException;
+import com.zerobase.cms.user.exception.ErrorCode;
+import com.zerobase.cms.user.service.customer.SignUpCustomerService;
+import com.zerobase.cms.user.service.seller.SellerService;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SignUpApplicationTest {
+
+    @Mock
+    private MailgunClient mailgunClient;
+
+    @Mock
+    private SignUpCustomerService signUpCustomerService;
+
+    @Mock
+    private SellerService sellerService;
+
+    @InjectMocks
+    private SignUpApplication signUpApplication;
+
+    @Test
+    void customerSignUpSuccess() {
+        SignUpForm form = SignUpForm.builder()
+            .birth(LocalDate.now())
+            .email("zerobase@naver.com")
+            .name("name")
+            .password("a123456@#")
+            .phone("01011112222")
+            .build();
+
+        given(signUpCustomerService.signUp(form))
+            .willReturn(Customer.from(form));
+
+        assertEquals(signUpApplication.customerSignUp(form), "회원 가입에 성공하였습니다.");
+    }
+
+    @Test
+    void customerSignUpFail_ALREADY_REGISTER_USER() {
+        SignUpForm form = SignUpForm.builder()
+            .birth(LocalDate.now())
+            .email("zerobase@naver.com")
+            .name("name")
+            .password("a123456@#")
+            .phone("01011112222")
+            .build();
+
+        given(signUpCustomerService.isEmailExist(form.getEmail()))
+            .willReturn(true);
+
+        CustomException exception = assertThrows(CustomException.class,
+            () -> signUpApplication.customerSignUp(form));
+
+        assertEquals(ErrorCode.ALREADY_REGISTER_USER, exception.getErrorCode());
+        assertEquals("이미 가입한 회원입니다.", exception.getMessage());
+    }
+
+    @Test
+    void customerSignUpFail_NOT_VALID_EMAIL() {
+        SignUpForm form = SignUpForm.builder()
+            .birth(LocalDate.now())
+            .email("zerobase")
+            .name("name")
+            .password("a123456@#")
+            .phone("01011112222")
+            .build();
+
+        CustomException exception = assertThrows(CustomException.class,
+            () -> signUpApplication.customerSignUp(form));
+
+        assertEquals(ErrorCode.NOT_VALID_EMAIL, exception.getErrorCode());
+        assertEquals("이메일 형식을 확인해주세요.", exception.getMessage());
+    }
+
+    @Test
+    void customerSignUpFail_NOT_VALID_PHONE() {
+        SignUpForm form = SignUpForm.builder()
+            .birth(LocalDate.now())
+            .email("zerobase@naver.com")
+            .name("name")
+            .password("a123456@#")
+            .phone("2345")
+            .build();
+
+        CustomException exception = assertThrows(CustomException.class,
+            () -> signUpApplication.customerSignUp(form));
+
+        assertEquals(ErrorCode.NOT_VALID_PHONE, exception.getErrorCode());
+        assertEquals("핸드폰 번호 형식을 확인해주세요.", exception.getMessage());
+    }
+
+    @Test
+    void customerSignUpFail_NOT_VALID_PASSWORD() {
+        SignUpForm form = SignUpForm.builder()
+            .birth(LocalDate.now())
+            .email("zerobase@naver.com")
+            .name("name")
+            .password("1111")
+            .phone("01011112222")
+            .build();
+
+        CustomException exception = assertThrows(CustomException.class,
+            () -> signUpApplication.customerSignUp(form));
+
+        assertEquals(ErrorCode.NOT_VALID_PASSWORD, exception.getErrorCode());
+        assertEquals("비밀번호는 최소 8자리에 숫자, 문자, 특수문자 각각 1개 이상 포함해야 합니다.", exception.getMessage());
+    }
+
+    @Test
+    void sellerSignUpSuccess() {
+        SignUpForm form = SignUpForm.builder()
+            .birth(LocalDate.now())
+            .email("zerobase@naver.com")
+            .name("name")
+            .password("a123456@#")
+            .phone("01011112222")
+            .build();
+
+        given(sellerService.signUp(form))
+            .willReturn(Seller.from(form));
+
+        assertEquals(signUpApplication.sellerSignUp(form), "회원 가입에 성공하였습니다.");
+    }
+
+    @Test
+    void sellerSignUpFail_ALREADY_REGISTER_USER() {
+        SignUpForm form = SignUpForm.builder()
+            .birth(LocalDate.now())
+            .email("zerobase@naver.com")
+            .name("name")
+            .password("a123456@#")
+            .phone("01011112222")
+            .build();
+
+        given(sellerService.isEmailExist(form.getEmail()))
+            .willReturn(true);
+
+        CustomException exception = assertThrows(CustomException.class,
+            () -> signUpApplication.sellerSignUp(form));
+
+        assertEquals(ErrorCode.ALREADY_REGISTER_USER, exception.getErrorCode());
+        assertEquals("이미 가입한 회원입니다.", exception.getMessage());
+    }
+
+    @Test
+    void sellerSignUpFail_NOT_VALID_EMAIL() {
+        SignUpForm form = SignUpForm.builder()
+            .birth(LocalDate.now())
+            .email("zerobase")
+            .name("name")
+            .password("a123456@#")
+            .phone("01011112222")
+            .build();
+
+        CustomException exception = assertThrows(CustomException.class,
+            () -> signUpApplication.sellerSignUp(form));
+
+        assertEquals(ErrorCode.NOT_VALID_EMAIL, exception.getErrorCode());
+        assertEquals("이메일 형식을 확인해주세요.", exception.getMessage());
+    }
+
+    @Test
+    void sellerSignUpFail_NOT_VALID_PHONE() {
+        SignUpForm form = SignUpForm.builder()
+            .birth(LocalDate.now())
+            .email("zerobase@naver.com")
+            .name("name")
+            .password("a123456@#")
+            .phone("2345")
+            .build();
+
+        CustomException exception = assertThrows(CustomException.class,
+            () -> signUpApplication.sellerSignUp(form));
+
+        assertEquals(ErrorCode.NOT_VALID_PHONE, exception.getErrorCode());
+        assertEquals("핸드폰 번호 형식을 확인해주세요.", exception.getMessage());
+    }
+
+    @Test
+    void sellerSignUpFail_NOT_VALID_PASSWORD() {
+        SignUpForm form = SignUpForm.builder()
+            .birth(LocalDate.now())
+            .email("zerobase@naver.com")
+            .name("name")
+            .password("1111")
+            .phone("01011112222")
+            .build();
+
+        CustomException exception = assertThrows(CustomException.class,
+            () -> signUpApplication.sellerSignUp(form));
+
+        assertEquals(ErrorCode.NOT_VALID_PASSWORD, exception.getErrorCode());
+        assertEquals("비밀번호는 최소 8자리에 숫자, 문자, 특수문자 각각 1개 이상 포함해야 합니다.", exception.getMessage());
+    }
+}

--- a/user-api/src/test/java/com/zerobase/cms/user/controller/SignUpControllerTest.java
+++ b/user-api/src/test/java/com/zerobase/cms/user/controller/SignUpControllerTest.java
@@ -1,0 +1,315 @@
+package com.zerobase.cms.user.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.cms.user.application.SignUpApplication;
+import com.zerobase.cms.user.domain.SignUpForm;
+import com.zerobase.cms.user.exception.CustomException;
+import com.zerobase.cms.user.exception.ErrorCode;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SignUpControllerTest {
+
+    @MockBean
+    private SignUpApplication signUpApplication;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void customerSignUpSuccess() throws Exception {
+        given(signUpApplication.customerSignUp(any()))
+            .willReturn("회원 가입에 성공하였습니다.");
+
+        mockMvc.perform(post("/signup/customer")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                    new SignUpForm("yjjjjwww@naver.com", "name", "123456!@", LocalDate.now(),
+                        "01011112222")
+                )))
+            .andExpect(status().isOk())
+            .andDo(print());
+    }
+
+    @Test
+    void customerSignUpFail_ALREADY_REGISTER_USER() throws Exception {
+        given(signUpApplication.customerSignUp(any()))
+            .willThrow(new CustomException(ErrorCode.ALREADY_REGISTER_USER));
+
+        mockMvc.perform(post("/signup/customer")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                    new SignUpForm("yjjjjwww@naver.com", "name", "123456!@", LocalDate.now(),
+                        "01011112222")
+                )))
+            .andExpect(jsonPath("$.errorCode").value("ALREADY_REGISTER_USER"))
+            .andExpect(jsonPath("$.message").value("이미 가입한 회원입니다."))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+    }
+
+    @Test
+    void customerSignUpFail_NOT_VALID_EMAIL() throws Exception {
+        given(signUpApplication.customerSignUp(any()))
+            .willThrow(new CustomException(ErrorCode.NOT_VALID_EMAIL));
+
+        mockMvc.perform(post("/signup/customer")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                    new SignUpForm("yjjjjwww@naver.com", "name", "123456!@", LocalDate.now(),
+                        "01011112222")
+                )))
+            .andExpect(jsonPath("$.errorCode").value("NOT_VALID_EMAIL"))
+            .andExpect(jsonPath("$.message").value("이메일 형식을 확인해주세요."))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+    }
+
+    @Test
+    void customerSignUpFail_NOT_VALID_PHONE() throws Exception {
+        given(signUpApplication.customerSignUp(any()))
+            .willThrow(new CustomException(ErrorCode.NOT_VALID_PHONE));
+
+        mockMvc.perform(post("/signup/customer")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                    new SignUpForm("yjjjjwww@naver.com", "name", "123456!@", LocalDate.now(),
+                        "01011112222")
+                )))
+            .andExpect(jsonPath("$.errorCode").value("NOT_VALID_PHONE"))
+            .andExpect(jsonPath("$.message").value("핸드폰 번호 형식을 확인해주세요."))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+    }
+
+    @Test
+    void customerSignUpFail_NOT_VALID_PASSWORD() throws Exception {
+        given(signUpApplication.customerSignUp(any()))
+            .willThrow(new CustomException(ErrorCode.NOT_VALID_PASSWORD));
+
+        mockMvc.perform(post("/signup/customer")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                    new SignUpForm("yjjjjwww@naver.com", "name", "123456!@", LocalDate.now(),
+                        "01011112222")
+                )))
+            .andExpect(jsonPath("$.errorCode").value("NOT_VALID_PASSWORD"))
+            .andExpect(jsonPath("$.message").value("비밀번호는 최소 8자리에 숫자, 문자, 특수문자 각각 1개 이상 포함해야 합니다."))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+    }
+
+    @Test
+    void verifyCustomerSuccess() throws Exception {
+        mockMvc.perform(get("/signup/customer/verify?email=yjjjwww@naver.com&code=1111"))
+            .andExpect(status().isOk())
+            .andDo(print());
+    }
+
+    @Test
+    void verifyCustomerFail_NOT_FOUND_USER() throws Exception {
+        doThrow(new CustomException(ErrorCode.NOT_FOUND_USER)).when(signUpApplication)
+            .customerVerify(anyString(), anyString());
+
+        mockMvc.perform(get("/signup/customer/verify?email=yjjjwww@naver.com&code=1111"))
+            .andExpect(jsonPath("$.errorCode").value("NOT_FOUND_USER"))
+            .andExpect(jsonPath("$.message").value("일치하는 회원이 없습니다."))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+    }
+
+    @Test
+    void verifyCustomerFail_ALREADY_VERIFY() throws Exception {
+        doThrow(new CustomException(ErrorCode.ALREADY_VERIFY)).when(signUpApplication)
+            .customerVerify(anyString(), anyString());
+
+        mockMvc.perform(get("/signup/customer/verify?email=yjjjwww@naver.com&code=1111"))
+            .andExpect(jsonPath("$.errorCode").value("ALREADY_VERIFY"))
+            .andExpect(jsonPath("$.message").value("이미 인증이 완료되었습니다."))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+    }
+
+    @Test
+    void verifyCustomerFail_WRONG_VERIFICATION() throws Exception {
+        doThrow(new CustomException(ErrorCode.WRONG_VERIFICATION)).when(signUpApplication)
+            .customerVerify(anyString(), anyString());
+
+        mockMvc.perform(get("/signup/customer/verify?email=yjjjwww@naver.com&code=1111"))
+            .andExpect(jsonPath("$.errorCode").value("WRONG_VERIFICATION"))
+            .andExpect(jsonPath("$.message").value("잘못된 인증 시도입니다."))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+    }
+
+    @Test
+    void verifyCustomerFail_EXPIRE_CODE() throws Exception {
+        doThrow(new CustomException(ErrorCode.EXPIRE_CODE)).when(signUpApplication)
+            .customerVerify(anyString(), anyString());
+
+        mockMvc.perform(get("/signup/customer/verify?email=yjjjwww@naver.com&code=1111"))
+            .andExpect(jsonPath("$.errorCode").value("EXPIRE_CODE"))
+            .andExpect(jsonPath("$.message").value("인증 시간이 만료되었습니다."))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+    }
+
+    @Test
+    void sellerSignUpSuccess() throws Exception {
+        given(signUpApplication.sellerSignUp(any()))
+            .willReturn("회원 가입에 성공하였습니다.");
+
+        mockMvc.perform(post("/signup/seller")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                    new SignUpForm("yjjjjwww@naver.com", "name", "123456!@", LocalDate.now(),
+                        "01011112222")
+                )))
+            .andExpect(status().isOk())
+            .andDo(print());
+    }
+
+    @Test
+    void sellerSignUpFail_ALREADY_REGISTER_USER() throws Exception {
+        given(signUpApplication.sellerSignUp(any()))
+            .willThrow(new CustomException(ErrorCode.ALREADY_REGISTER_USER));
+
+        mockMvc.perform(post("/signup/seller")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                    new SignUpForm("yjjjjwww@naver.com", "name", "123456!@", LocalDate.now(),
+                        "01011112222")
+                )))
+            .andExpect(jsonPath("$.errorCode").value("ALREADY_REGISTER_USER"))
+            .andExpect(jsonPath("$.message").value("이미 가입한 회원입니다."))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+    }
+
+    @Test
+    void sellerSignUpFail_NOT_VALID_EMAIL() throws Exception {
+        given(signUpApplication.sellerSignUp(any()))
+            .willThrow(new CustomException(ErrorCode.NOT_VALID_EMAIL));
+
+        mockMvc.perform(post("/signup/seller")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                    new SignUpForm("yjjjjwww@naver.com", "name", "123456!@", LocalDate.now(),
+                        "01011112222")
+                )))
+            .andExpect(jsonPath("$.errorCode").value("NOT_VALID_EMAIL"))
+            .andExpect(jsonPath("$.message").value("이메일 형식을 확인해주세요."))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+    }
+
+    @Test
+    void sellerSignUpFail_NOT_VALID_PHONE() throws Exception {
+        given(signUpApplication.sellerSignUp(any()))
+            .willThrow(new CustomException(ErrorCode.NOT_VALID_PHONE));
+
+        mockMvc.perform(post("/signup/seller")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                    new SignUpForm("yjjjjwww@naver.com", "name", "123456!@", LocalDate.now(),
+                        "01011112222")
+                )))
+            .andExpect(jsonPath("$.errorCode").value("NOT_VALID_PHONE"))
+            .andExpect(jsonPath("$.message").value("핸드폰 번호 형식을 확인해주세요."))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+    }
+
+    @Test
+    void sellerSignUpFail_NOT_VALID_PASSWORD() throws Exception {
+        given(signUpApplication.sellerSignUp(any()))
+            .willThrow(new CustomException(ErrorCode.NOT_VALID_PASSWORD));
+
+        mockMvc.perform(post("/signup/seller")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                    new SignUpForm("yjjjjwww@naver.com", "name", "123456!@", LocalDate.now(),
+                        "01011112222")
+                )))
+            .andExpect(jsonPath("$.errorCode").value("NOT_VALID_PASSWORD"))
+            .andExpect(jsonPath("$.message").value("비밀번호는 최소 8자리에 숫자, 문자, 특수문자 각각 1개 이상 포함해야 합니다."))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+    }
+
+    @Test
+    void verifySellerSuccess() throws Exception {
+        mockMvc.perform(get("/signup/seller/verify?email=yjjjwww@naver.com&code=1111"))
+            .andExpect(status().isOk())
+            .andDo(print());
+    }
+
+    @Test
+    void verifySellerFail_NOT_FOUND_USER() throws Exception {
+        doThrow(new CustomException(ErrorCode.NOT_FOUND_USER)).when(signUpApplication)
+            .sellerVerify(anyString(), anyString());
+
+        mockMvc.perform(get("/signup/seller/verify?email=yjjjwww@naver.com&code=1111"))
+            .andExpect(jsonPath("$.errorCode").value("NOT_FOUND_USER"))
+            .andExpect(jsonPath("$.message").value("일치하는 회원이 없습니다."))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+    }
+
+    @Test
+    void verifySellerFail_ALREADY_VERIFY() throws Exception {
+        doThrow(new CustomException(ErrorCode.ALREADY_VERIFY)).when(signUpApplication)
+            .sellerVerify(anyString(), anyString());
+
+        mockMvc.perform(get("/signup/seller/verify?email=yjjjwww@naver.com&code=1111"))
+            .andExpect(jsonPath("$.errorCode").value("ALREADY_VERIFY"))
+            .andExpect(jsonPath("$.message").value("이미 인증이 완료되었습니다."))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+    }
+
+    @Test
+    void verifySellerFail_WRONG_VERIFICATION() throws Exception {
+        doThrow(new CustomException(ErrorCode.WRONG_VERIFICATION)).when(signUpApplication)
+            .sellerVerify(anyString(), anyString());
+
+        mockMvc.perform(get("/signup/seller/verify?email=yjjjwww@naver.com&code=1111"))
+            .andExpect(jsonPath("$.errorCode").value("WRONG_VERIFICATION"))
+            .andExpect(jsonPath("$.message").value("잘못된 인증 시도입니다."))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+    }
+
+    @Test
+    void verifySellerFail_EXPIRE_CODE() throws Exception {
+        doThrow(new CustomException(ErrorCode.EXPIRE_CODE)).when(signUpApplication)
+            .sellerVerify(anyString(), anyString());
+
+        mockMvc.perform(get("/signup/seller/verify?email=yjjjwww@naver.com&code=1111"))
+            .andExpect(jsonPath("$.errorCode").value("EXPIRE_CODE"))
+            .andExpect(jsonPath("$.message").value("인증 시간이 만료되었습니다."))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+    }
+}

--- a/user-api/src/test/java/com/zerobase/cms/user/service/seller/SellerServiceTest.java
+++ b/user-api/src/test/java/com/zerobase/cms/user/service/seller/SellerServiceTest.java
@@ -1,4 +1,4 @@
-package com.zerobase.cms.user.client.service;
+package com.zerobase.cms.user.service.seller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -10,11 +10,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.zerobase.cms.user.domain.SignUpForm;
-import com.zerobase.cms.user.domain.model.Customer;
-import com.zerobase.cms.user.domain.repository.CustomerRepository;
+import com.zerobase.cms.user.domain.model.Seller;
+import com.zerobase.cms.user.domain.repository.SellerRepository;
 import com.zerobase.cms.user.exception.CustomException;
 import com.zerobase.cms.user.exception.ErrorCode;
-import com.zerobase.cms.user.service.customer.SignUpCustomerService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -27,13 +26,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class SignUpCustomerServiceTest {
+class SellerServiceTest {
 
     @Mock
-    private CustomerRepository customerRepository;
+    private SellerRepository sellerRepository;
 
     @InjectMocks
-    private SignUpCustomerService signUpCustomerService;
+    private SellerService sellerService;
 
     @Test
     void signUp() {
@@ -45,40 +44,40 @@ class SignUpCustomerServiceTest {
             .phone("01000000000")
             .build();
 
-        given(customerRepository.save(any()))
-            .willReturn(Customer.from(form));
+        given(sellerRepository.save(any()))
+            .willReturn(Seller.from(form));
 
-        ArgumentCaptor<Customer> captor = ArgumentCaptor.forClass(Customer.class);
+        ArgumentCaptor<Seller> captor = ArgumentCaptor.forClass(Seller.class);
 
-        Customer customer = signUpCustomerService.signUp(form);
+        Seller seller = sellerService.signUp(form);
 
-        verify(customerRepository, times(1)).save(captor.capture());
-        assertEquals("name", customer.getName());
+        verify(sellerRepository, times(1)).save(captor.capture());
+        assertEquals("name", seller.getName());
     }
 
     @Test
     void isEmailExist() {
-        given(customerRepository.findByEmail(anyString()))
-            .willReturn(Optional.ofNullable(Customer.builder().build()));
+        given(sellerRepository.findByEmail(anyString()))
+            .willReturn(Optional.ofNullable(Seller.builder().build()));
 
-        boolean result = signUpCustomerService.isEmailExist("email");
+        boolean result = sellerService.isEmailExist("email");
 
         assertEquals(true, result);
     }
 
     @Test
     void isEmailNotExist() {
-        given(customerRepository.findByEmail(anyString()))
+        given(sellerRepository.findByEmail(anyString()))
             .willReturn(Optional.empty());
 
-        boolean result = signUpCustomerService.isEmailExist("email");
+        boolean result = sellerService.isEmailExist("email");
 
         assertEquals(false, result);
     }
 
     @Test
     void verifyEmailSuccess() {
-        Customer customerBeforeVerify = Customer.builder()
+        Seller sellerBeforeVerify = Seller.builder()
             .email("zerobase@naver.com")
             .name("zerobase")
             .password("zero1234@!#")
@@ -89,23 +88,23 @@ class SignUpCustomerServiceTest {
             .verify(false)
             .build();
 
-        given(customerRepository.findByEmail(anyString()))
-            .willReturn(Optional.ofNullable(customerBeforeVerify));
+        given(sellerRepository.findByEmail(anyString()))
+            .willReturn(Optional.ofNullable(sellerBeforeVerify));
 
-        ArgumentCaptor<Customer> captor = ArgumentCaptor.forClass(Customer.class);
+        ArgumentCaptor<Seller> captor = ArgumentCaptor.forClass(Seller.class);
 
-        signUpCustomerService.verifyEmail("zerobase@naver.com", "0000");
+        sellerService.verifyEmail("zerobase@naver.com", "0000");
 
-        verify(customerRepository, times(1)).save(captor.capture());
+        verify(sellerRepository, times(1)).save(captor.capture());
     }
 
     @Test
     void verifyEmailFail_NOT_FOUND_USER() {
-        given(customerRepository.findByEmail(anyString()))
+        given(sellerRepository.findByEmail(anyString()))
             .willReturn(Optional.empty());
 
         CustomException exception = assertThrows(CustomException.class,
-            () -> signUpCustomerService.verifyEmail("zerobase", "1111"));
+            () -> sellerService.verifyEmail("zerobase", "1111"));
 
         assertEquals(ErrorCode.NOT_FOUND_USER, exception.getErrorCode());
         assertEquals("일치하는 회원이 없습니다.", exception.getMessage());
@@ -113,7 +112,7 @@ class SignUpCustomerServiceTest {
 
     @Test
     void verifyEmailFail_ALREADY_VERIFY() {
-        Customer customerBeforeVerify = Customer.builder()
+        Seller sellerBeforeVerify = Seller.builder()
             .email("zerobase@naver.com")
             .name("zerobase")
             .password("zero1234@!#")
@@ -124,11 +123,11 @@ class SignUpCustomerServiceTest {
             .verify(true)
             .build();
 
-        given(customerRepository.findByEmail(anyString()))
-            .willReturn(Optional.ofNullable(customerBeforeVerify));
+        given(sellerRepository.findByEmail(anyString()))
+            .willReturn(Optional.ofNullable(sellerBeforeVerify));
 
         CustomException exception = assertThrows(CustomException.class,
-            () -> signUpCustomerService.verifyEmail("zerobase", "1111"));
+            () -> sellerService.verifyEmail("zerobase", "1111"));
 
         assertEquals(ErrorCode.ALREADY_VERIFY, exception.getErrorCode());
         assertEquals("이미 인증이 완료되었습니다.", exception.getMessage());
@@ -136,7 +135,7 @@ class SignUpCustomerServiceTest {
 
     @Test
     void verifyEmailFail_WRONG_VERIFICATION() {
-        Customer customerBeforeVerify = Customer.builder()
+        Seller sellerBeforeVerify = Seller.builder()
             .email("zerobase@naver.com")
             .name("zerobase")
             .password("zero1234@!#")
@@ -147,11 +146,11 @@ class SignUpCustomerServiceTest {
             .verify(false)
             .build();
 
-        given(customerRepository.findByEmail(anyString()))
-            .willReturn(Optional.ofNullable(customerBeforeVerify));
+        given(sellerRepository.findByEmail(anyString()))
+            .willReturn(Optional.ofNullable(sellerBeforeVerify));
 
         CustomException exception = assertThrows(CustomException.class,
-            () -> signUpCustomerService.verifyEmail("zerobase", "1111"));
+            () -> sellerService.verifyEmail("zerobase", "1111"));
 
         assertEquals(ErrorCode.WRONG_VERIFICATION, exception.getErrorCode());
         assertEquals("잘못된 인증 시도입니다.", exception.getMessage());
@@ -159,7 +158,7 @@ class SignUpCustomerServiceTest {
 
     @Test
     void verifyEmailFail_EXPIRE_CODE() {
-        Customer customerBeforeVerify = Customer.builder()
+        Seller sellerBeforeVerify = Seller.builder()
             .email("zerobase@naver.com")
             .name("zerobase")
             .password("zero1234@!#")
@@ -170,11 +169,11 @@ class SignUpCustomerServiceTest {
             .verify(false)
             .build();
 
-        given(customerRepository.findByEmail(anyString()))
-            .willReturn(Optional.ofNullable(customerBeforeVerify));
+        given(sellerRepository.findByEmail(anyString()))
+            .willReturn(Optional.ofNullable(sellerBeforeVerify));
 
         CustomException exception = assertThrows(CustomException.class,
-            () -> signUpCustomerService.verifyEmail("zerobase", "0000"));
+            () -> sellerService.verifyEmail("zerobase", "0000"));
 
         assertEquals(ErrorCode.EXPIRE_CODE, exception.getErrorCode());
         assertEquals("인증 시간이 만료되었습니다.", exception.getMessage());
@@ -182,7 +181,7 @@ class SignUpCustomerServiceTest {
 
     @Test
     void changeCustomerValidateEmail() {
-        Customer customer = Customer.builder()
+        Seller customer = Seller.builder()
             .email("zerobase@naver.com")
             .name("zerobase")
             .password("zero1234@!#")
@@ -193,10 +192,10 @@ class SignUpCustomerServiceTest {
             .verify(false)
             .build();
 
-        given(customerRepository.findById(anyLong()))
+        given(sellerRepository.findById(anyLong()))
             .willReturn(Optional.ofNullable(customer));
 
-        LocalDateTime result = signUpCustomerService.changeCustomerValidateEmail(1L, "0000");
+        LocalDateTime result = sellerService.changeSellerValidateEmail(1L, "0000");
 
         assertEquals(LocalDateTime.now().plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")), result.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
     }


### PR DESCRIPTION
Changes
___

test : [019-SIGNUP-TEST] 회원 가입 테스트 코드 구현

-SignUpController : 
1. signup/customer
회원 가입 성공, 회원 가입 실패(이미 가입한 회원, 잘못된 이메일 형식, 잘못된 핸드폰 번호 형식, 잘못된 비밀번호 형식)
2. signup/customer/verify
인증 성공, 인증 실패(이미 인증된 회원, 잘못된 인증 시도, 인증 시간 만료)
3. signup/seller
회원 가입 성공, 회원 가입 실패(이미 가입한 회원, 잘못된 이메일 형식, 잘못된 핸드폰 번호 형식, 잘못된 비밀번호 형식)
4. signup/seller/verify
인증 성공, 인증 실패(이미 인증된 회원, 잘못된 인증 시도, 인증 시간 만료)

-SignUpApplication
customer, seller에 대해 회원 가입 성공, 회원 가입 실패(이미 가입한 회원, 잘못된 이메일 형식, 잘못된 핸드폰 번호 형식, 잘못된 비밀번호 형식)

-SignUpCustomerService, SellerService
1. 회원 가입 시 customer, seller 데이터베이스 저장
2. 이메일로 회원 정보 유무 확인
3. 이메일로 회원 정보 조회 및 인증
4. 인증 시간 설정